### PR TITLE
Add `NO_COMPONENTS` macro

### DIFF
--- a/include/pecs.h
+++ b/include/pecs.h
@@ -3,6 +3,8 @@
 
 #include <stdlib.h>
 
+#define NO_COMPONENTS 0
+
 typedef unsigned int Entity, ComponentType, Signature;
 
 typedef struct Registry {

--- a/src/example.c
+++ b/src/example.c
@@ -30,9 +30,9 @@ int main() {
     // NULL to create an empty entity.
     Entity player = CreateEntity(reg, transform + health);
     // player is an Entity with Transform and Health components.
-    Entity empty = CreateEntity(reg, NULL);
-    // empty is an entity with no components. You can also pass
-    // 0 to CreateEntity instead of NULL.
+    Entity empty = CreateEntity(reg, NO_COMPONENTS);
+    // Pass NO_COMPONENTS as the signature to create
+    // an entity with no components (empty entity).
 
     // You can check if an entity has atleast a certain combination
     // of entities by using HasComponents. Pass the Registry pointer,


### PR DESCRIPTION
`#define NO_COMPONENTS 0`
To be passed as the `signature` to `CreateEntity()` when an empty entity
is desired.
Example:
`Entity empty_entity = CreateEntity(reg, NO_COMPONENTS);`